### PR TITLE
[PIDM-2218] fix: check flow IUR against payment option receipt before reporting

### DIFF
--- a/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
+++ b/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
@@ -74,36 +74,21 @@ public class GpdReportingSync {
             + " iur=" + reportedIUVEventModel.getIur() + " flow=" + reportedIUVEventModel.getFlowId();
 
         try {
-            HttpResponse<String> getResponse = Unirest.get(gpdBasePath
-                    + "/organizations/" + organizationId
-                    + "/paymentoptions/" + iuv + "/debtposition")
-                .header("accept", "application/json")
-                .header("ocp-apim-subscription-key", gpdSubeKey)
-                .asString();
 
             String iur = reportedIUVEventModel.getIur();
-
-            if (getResponse.getStatus() == 200 && iur != null && !iur.isBlank()) {
-                JsonNode position = new ObjectMapper().readTree(getResponse.getBody());
-                for (JsonNode po : position.path("paymentOption")) {
-                    if (iuv.equals(po.path("iuv").asText(null))) {
-                        // receipt field: idReceipt/receiptId, to be aligned with the actual contract
-                        String poReceiptId = po.path("idReceipt").asText(null);
-                        if (poReceiptId != null && !iur.equals(poReceiptId)) {
-                            logger.log(Level.SEVERE, () -> ctx + " SKIP report: IUR mismatch"
-                                + " (paymentOption receipt=" + poReceiptId + ")"
-                                + " - the reporting flow refers to a different payment,"
-                                + " no state transition performed");
-                            return;
-                        }
-                        break;
-                    }
-                }
+            String body;
+            try {
+                body = new ObjectMapper()
+                    .writeValueAsString(java.util.Collections.singletonMap("iur", iur));
+            } catch (Exception e) {
+                body = "{}";
             }
 
             HttpResponse<String> response = Unirest.post(gpdBasePath + "/organizations/" + organizationId + "/paymentoptions/" + iuv + "/transfers/" + transferId + "/report")
                     .header("accept", "application/json")
                     .header("ocp-apim-subscription-key", gpdSubeKey)
+                    .header("Content-Type", "application/json")
+                    .body(body)
                     .asString();
             if (response.getStatus() != 200) {
                 logger.log(Level.SEVERE, () -> "[GpdReportingSync] GPD client failed with status " + response.getStatus() + " body:" + response.getBody());

--- a/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
+++ b/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
@@ -55,10 +55,10 @@ public class GpdReportingSync {
                 continue;
             }
 
-            // In FDR-1, transferId is not mandatory if there is only one transfer;
+            // In FDR-1, transferId is not mandatory
             // If ID_TRANSFER is null override with 1.
-            if (reportedIUVEventModel.getIdTransfer() == null) {
-                reportedIUVEventModel.setIdTransfer(1L);
+            if (reportedIUVEventModel.getIdsp() == null) {
+                reportedIUVEventModel.setIdsp("1");
             }
 
             gpdReport(logger, reportedIUVEventModel);
@@ -69,7 +69,7 @@ public class GpdReportingSync {
     public void gpdReport(Logger logger,  ReportedIUVEventModel reportedIUVEventModel){
         String organizationId = reportedIUVEventModel.getDomainId();
         String iuv = reportedIUVEventModel.getIuv();
-        String transferId = String.valueOf(reportedIUVEventModel.getIdTransfer());
+        String transferId = String.valueOf(reportedIUVEventModel.getIdsp());
         String ctx = "[GpdReportingSync] org=" + organizationId + " iuv=" + iuv
             + " iur=" + reportedIUVEventModel.getIur() + " flow=" + reportedIUVEventModel.getFlowId();
 

--- a/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
+++ b/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.reporting;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
@@ -60,13 +61,46 @@ public class GpdReportingSync {
                 reportedIUVEventModel.setIdTransfer(1L);
             }
 
-            gpdReport(logger, reportedIUVEventModel.getDomainId(), reportedIUVEventModel.getIuv(), String.valueOf(reportedIUVEventModel.getIdTransfer()));
+            gpdReport(logger, reportedIUVEventModel);
         }
 
     }
 
-    public void gpdReport(Logger logger, String organizationId, String iuv, String transferId) {
+    public void gpdReport(Logger logger,  ReportedIUVEventModel reportedIUVEventModel){
+        String organizationId = reportedIUVEventModel.getDomainId();
+        String iuv = reportedIUVEventModel.getIuv();
+        String transferId = String.valueOf(reportedIUVEventModel.getIdTransfer());
+        String ctx = "[GpdReportingSync] org=" + organizationId + " iuv=" + iuv
+            + " iur=" + reportedIUVEventModel.getIur() + " flow=" + reportedIUVEventModel.getFlowId();
+
         try {
+            HttpResponse<String> getResponse = Unirest.get(gpdBasePath
+                    + "/organizations/" + organizationId
+                    + "/paymentoptions/" + iuv + "/debtposition")
+                .header("accept", "application/json")
+                .header("ocp-apim-subscription-key", gpdSubeKey)
+                .asString();
+
+            String iur = reportedIUVEventModel.getIur();
+
+            if (getResponse.getStatus() == 200 && iur != null && !iur.isBlank()) {
+                JsonNode position = new ObjectMapper().readTree(getResponse.getBody());
+                for (JsonNode po : position.path("paymentOption")) {
+                    if (iuv.equals(po.path("iuv").asText(null))) {
+                        // receipt field: idReceipt/receiptId, to be aligned with the actual contract
+                        String poReceiptId = po.path("idReceipt").asText(null);
+                        if (poReceiptId != null && !iur.equals(poReceiptId)) {
+                            logger.log(Level.SEVERE, () -> ctx + " SKIP report: IUR mismatch"
+                                + " (paymentOption receipt=" + poReceiptId + ")"
+                                + " - the reporting flow refers to a different payment,"
+                                + " no state transition performed");
+                            return;
+                        }
+                        break;
+                    }
+                }
+            }
+
             HttpResponse<String> response = Unirest.post(gpdBasePath + "/organizations/" + organizationId + "/paymentoptions/" + iuv + "/transfers/" + transferId + "/report")
                     .header("accept", "application/json")
                     .header("ocp-apim-subscription-key", gpdSubeKey)

--- a/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
+++ b/src/main/java/it/gov/pagopa/reporting/GpdReportingSync.java
@@ -91,10 +91,10 @@ public class GpdReportingSync {
                     .body(body)
                     .asString();
             if (response.getStatus() != 200) {
-                logger.log(Level.SEVERE, () -> "[GpdReportingSync] GPD client failed with status " + response.getStatus() + " body:" + response.getBody());
+                logger.log(Level.SEVERE, () -> ctx + "[GpdReportingSync] GPD client failed with status " + response.getStatus() + " body:" + response.getBody());
             }
         } catch (Exception e) {
-            logger.log(Level.SEVERE, () -> "[GpdReportingSync] GPD client Exception: " + e.getLocalizedMessage());
+            logger.log(Level.SEVERE, () -> ctx + "[GpdReportingSync] GPD client Exception: " + e.getLocalizedMessage());
         }
     }
 

--- a/src/test/java/it/gov/pagopa/reporting/GpdReportingSyncTest.java
+++ b/src/test/java/it/gov/pagopa/reporting/GpdReportingSyncTest.java
@@ -42,7 +42,7 @@ class GpdReportingSyncTest {
 
         function.run(messages,  context);
 
-        Mockito.verify(function, never()).gpdReport(any(), any(), any(), any());
+        Mockito.verify(function, never()).gpdReport(any(), any());
     }
 
     @Test
@@ -57,7 +57,7 @@ class GpdReportingSyncTest {
 
         function.run(messages, context);
 
-        Mockito.verify(function, times(1)).gpdReport(any(), any(), any(), any());
+        Mockito.verify(function, times(1)).gpdReport(any(), any());
     }
 
     @Test
@@ -73,6 +73,6 @@ class GpdReportingSyncTest {
 
         function.run(messages, context);
 
-        Mockito.verify(function, times(1)).gpdReport(any(), any(), any(), any());
+        Mockito.verify(function, times(1)).gpdReport(any(), any());
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- GpdReportingSync: idTransfer is now taken from the event IDSP field. In the FdR-1 pipeline the ReportedIUV event does not populate ID_TRANSFER; the upstream mapper puts indiceDatiSingoloPagamento into IDSP.
- The flow IUR is now forwarded to GPD in the /report request body (JSON {"iur": "..."}, null-safe serialization via Jackson). IUR (Identificativo Univoco Riscossione) uniquely identifies the payment and is already available in ReportedIUVEventModel. GPD can use it to resolve the payment option actually related to the reported payment instead of the ambiguous (organizationId, IUV) pair.
- gpdReport signature changed from (Logger, String, String, String) to (Logger, ReportedIUVEventModel), since it now needs IDSP, IUR and flow id.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.